### PR TITLE
Bugfix: Correcting the ListOffset API request (focused on version 9)

### DIFF
--- a/lib/src/apis/kafka_list_offset_api.dart
+++ b/lib/src/apis/kafka_list_offset_api.dart
@@ -23,6 +23,7 @@ class KafkaListOffsetApi {
     required List<Topic> topics,
     required int leaderEpoch,
     required int limit,
+    required DateTime timestamp,
   }) {
     final byteBuffer = BytesBuilder();
 
@@ -43,10 +44,9 @@ class KafkaListOffsetApi {
       for (Partition partition in topic.partitions ?? []) {
         byteBuffer.add(encoder.int32(partition.id));
         if (apiVersion > 3) {
-          // TODO: aqui preciso fazer a request LeaderAndIsr and pass the value
           byteBuffer.add(encoder.int32(leaderEpoch));
         }
-        byteBuffer.add(encoder.int64(DateTime.now().microsecondsSinceEpoch));
+        byteBuffer.add(encoder.int64(timestamp.microsecondsSinceEpoch));
         if (apiVersion == 0) {
           byteBuffer.add(encoder.int32(limit));
         }
@@ -78,7 +78,7 @@ class KafkaListOffsetApi {
   /// Method to deserialize the ListOffsetsResponse
   dynamic deserialize(Uint8List data, int apiVersion) {
     final buffer = ByteData.sublistView(data);
-    int offset = 1; // ignore the tagged_buffer
+    int offset = 0;
 
     final int throttleTimeMs = buffer.getInt32(offset);
     offset += 4;
@@ -137,5 +137,4 @@ class KafkaListOffsetApi {
 
     return ListOffsetResponse(throttleTimeMs: throttleTimeMs, topics: topics);
   }
-
 }

--- a/lib/src/kafka_consumer.dart
+++ b/lib/src/kafka_consumer.dart
@@ -166,6 +166,7 @@ class KafkaConsumer {
     int limit = 10,
     int replicaId = 0,
     required List<Topic> topics,
+    DateTime? timestamp,
   }) async {
     final List<Future<dynamic>> responses = [];
 
@@ -181,7 +182,8 @@ class KafkaConsumer {
           limit: limit,
           replicaId: replicaId,
           clientId: kafka.clientId,
-          topics: topics,
+          topics: [topic],
+          timestamp: timestamp ?? DateTime.utc(1970),
         );
 
         // print("${DateTime.now()} || [APP] ListOffsetRequest: $message");


### PR DESCRIPTION
- Ajudsted the ListOffsetRequest to accept the a DateTime optional parameter
  - The default value, if parameter isn't passed, is the UNIX timestamp.
- Corrected the "deserialize" method for this API to start the read at offset 0 instead of 1.
- Corrected the method in the class KafkaConsumer because it was sending multiple times all the topics informed
  - Altered to send a topic per request.